### PR TITLE
Fixed a typo that causes namespace error.

### DIFF
--- a/test/unit/controllers/SampleRouteController.spec.ts
+++ b/test/unit/controllers/SampleRouteController.spec.ts
@@ -9,7 +9,7 @@ describe('sample route controller', () => {
 
     let expect = chai.expect;
     let sandbox = sinon.sandbox.create();
-    let logInfoStub: Sinon.SinonStub;
+    let logInfoStub: sinon.SinonStub;
 
     beforeEach(() => {
         logInfoStub = sandbox.stub(logger, 'info');


### PR DESCRIPTION
This fixes TS2503 error thrown when issuing `npm run compile`.